### PR TITLE
Support for Maven Assembly to build archives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,9 @@ module.exports = {
   },
   extends: 'eslint:recommended',
   env: {
-    browser: true
+    browser: true,
+    node: true,
+    mocha: true
   },
   rules: {
   }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ distributionManagement: [{
 ```
 
 ### formats
-A list of formats as supported by the [Maven assembly plugin](http://maven.apache.org/plugins/maven-assembly-plugin/). If this field is set, this addon activates a Maven profile which will call the Maven assembly to build the desired assemblies.
+A list of formats as supported by the [Maven assembly plugin][6]. If this field is set, this addon activates a Maven profile which will execute the Maven assembly plug-in to build the desired assemblies.
 
 *Default:* `[]`
 
@@ -151,6 +151,7 @@ For more information on using ember-cli, visit [https://ember-cli.com/](https://
 [3]: https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN401 "The SNAPSHOT Qualifier"
 [4]: https://maven.apache.org/pom.html#Repositories "Repositories"
 [5]: https://maven.apache.org/pom.html#Distribution_Management "Distribution Management"
+[6]: http://maven.apache.org/plugins/maven-assembly-plugin/ "Maven Assembly Plugin"
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ distributionManagement: [{
 }]
 ```
 
+### formats
+A list of formats as supported by the [Maven assembly plugin](http://maven.apache.org/plugins/maven-assembly-plugin/). If this field is set, this addon activates a Maven profile which will call the Maven assembly to build the desired assemblies.
+
+*Default:* `[]`
+
+*Example:*
+
+```js
+formats: ['zip', 'tar.gz']
+```
+
 ## Running Tests
 
 * `yarn test`

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
         },
         packaging: 'jar',
         finalName: '${project.artifactId}-${project.version}-${git.commit.id.abbrev}',
+        formats: [],
         repositories: [],
         distributionManagement: []
       },
@@ -66,6 +67,15 @@ module.exports = {
           repositories: this.readConfig('repositories'),
           distributionManagement: this.readConfig('distributionManagement'),
           gitDirectoryPath: path.join(__dirname, ".git")
+        });
+      },
+
+      _buildAssemblyDescriptor() {
+        const assemblyDescriptorTemplatePath = path.join(__dirname, 'lib', 'assembly.xml.hbs');
+        const assemblyDescriptorTemplate = hbs.compile(fs.readFileSync(assemblyDescriptorTemplatePath, { encoding: 'utf8' }));
+
+        return assemblyDescriptorTemplate({
+          formats: this.readConfig('formats')
         });
       }
     });

--- a/index.js
+++ b/index.js
@@ -42,9 +42,10 @@ module.exports = {
       },
 
       upload: async function (context) {
-        const command = 'mvn deploy';
+        const command = this._buildMavenCommand();
         const distPath = path.join(context.project.root, context.config.build.outputPath);
 
+        await writeFile(path.join(distPath, 'assembly.xml'), this._buildAssemblyDescriptor());
         await writeFile(path.join(distPath, 'pom.xml'), this._buildPomContent());
 
         return exec(command, {cwd: distPath}).catch(e => {
@@ -52,6 +53,12 @@ module.exports = {
           e.message = e.message + "\n" + e.stdout + "\n" + e.stderr;
           throw e;
         })
+      },
+
+      _buildMavenCommand() {
+        const formats = (this.readConfig('formats') || []);
+
+        return 'mvn deploy' + (formats.length > 0 ? ' -Passembly' : '');
       },
 
       _buildPomContent() {

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const pomXmlTemplatePath = path.join(__dirname, 'lib', 'pom.xml.hbs');
 
 const pomXmlTemplate = hbs.compile(fs.readFileSync(pomXmlTemplatePath, {encoding: 'utf8'}));
 
+const assemblyDescriptorTemplatePath = path.join(__dirname, 'lib', 'assembly.xml.hbs');
+const assemblyDescriptorTemplate = hbs.compile(fs.readFileSync(assemblyDescriptorTemplatePath, { encoding: 'utf8' }));
+
 module.exports = {
   name: 'ember-cli-deploy-maven',
 
@@ -78,9 +81,6 @@ module.exports = {
       },
 
       _buildAssemblyDescriptor() {
-        const assemblyDescriptorTemplatePath = path.join(__dirname, 'lib', 'assembly.xml.hbs');
-        const assemblyDescriptorTemplate = hbs.compile(fs.readFileSync(assemblyDescriptorTemplatePath, { encoding: 'utf8' }));
-
         return assemblyDescriptorTemplate({
           formats: this.readConfig('formats')
         });

--- a/lib/assembly.xml.hbs
+++ b/lib/assembly.xml.hbs
@@ -1,0 +1,15 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>ember</id>
+  <formats>
+    {{#each formats as |format|}}
+      <format>{{format}}</format>
+    {{/each}}
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>build</directory>
+      <outputDirectory>./</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/lib/assembly.xml.hbs
+++ b/lib/assembly.xml.hbs
@@ -10,6 +10,11 @@
     <fileSet>
       <directory>build</directory>
       <outputDirectory>./</outputDirectory>
+      <excludes>
+        <exclude>pom.xml</exclude>
+        <exclude>assembly.xml</exclude>
+        <exclude>target/</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
 </assembly>

--- a/lib/assembly.xml.hbs
+++ b/lib/assembly.xml.hbs
@@ -8,7 +8,7 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>build</directory>
+      <directory>${project.basedir}</directory>
       <outputDirectory>./</outputDirectory>
       <excludes>
         <exclude>pom.xml</exclude>

--- a/lib/assembly.xml.hbs
+++ b/lib/assembly.xml.hbs
@@ -9,7 +9,6 @@
   <fileSets>
     <fileSet>
       <directory>${project.basedir}</directory>
-      <outputDirectory>./</outputDirectory>
       <excludes>
         <exclude>pom.xml</exclude>
         <exclude>assembly.xml</exclude>

--- a/lib/pom.xml.hbs
+++ b/lib/pom.xml.hbs
@@ -79,4 +79,34 @@
       </resource>
     </resources>
   </build>
+
+  <profiles>
+    <profile>
+      <id>assembly</id>
+      <build>
+      <plugins>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.0</version>
+          <configuration>
+            <descriptors>
+              <descriptor>assembly.xml</descriptor>
+            </descriptors>
+            <appendAssemblyId>false</appendAssemblyId>
+          </configuration>
+          <executions>
+            <execution>
+              <id>make-assembly</id>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "mocha tests/unit/index-test.js"
+    "test": "mocha tests/unit/*.js"
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "chai": "^4.1.2",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.16.2",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/tests/unit/assembly-test.js
+++ b/tests/unit/assembly-test.js
@@ -1,0 +1,43 @@
+const expect = require('chai').expect;
+const util = require('util');
+const parseString = util.promisify(require('xml2js').parseString);
+const plugin = require('../../index').createDeployPlugin({ name: 'maven' });
+
+describe('Assembly descriptor', function () {
+  const mockUi = {
+    verbose: true,
+    messages: [],
+    write() {},
+    writeLine: function (message) {
+      this.messages.push(message);
+    }
+  };
+
+  const context = {
+    ui: mockUi,
+    config: {}
+  };
+
+  beforeEach(function () {
+    context.config.maven = {
+      groupId: 'com.example.foo',
+      artifactId: 'dummy'
+    };
+  });
+
+  it('contains configured formats', async function () {
+    // given configured formats
+    context.config.maven.formats = ['zip', 'tar.gz'];
+
+    // when preparing the plguin and parsing the assembly descriptor XML
+    plugin.beforeHook(context);
+    plugin.configure(context);
+    const xml = await parseString(plugin._buildAssemblyDescriptor(), { explicitArray: false });
+
+    // then the XML contains the configured formats
+    expect(xml.assembly.formats.format).to.be.an('array')
+    expect(xml.assembly.formats.format).to.have.property('length', 2);
+    expect(xml.assembly.formats.format).to.include('zip');
+    expect(xml.assembly.formats.format).to.include('tar.gz');
+  });
+})

--- a/tests/unit/assembly-test.js
+++ b/tests/unit/assembly-test.js
@@ -57,4 +57,38 @@ describe('Assembly descriptor', function () {
     expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.include('assembly.xml');
     expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.include('target/');
   });
+
+  it('is referenced in a profile within the POM', async function () {
+    plugin.beforeHook(context);
+    plugin.configure(context);
+
+    const pom = await parseString(plugin._buildPomContent(), { explicitArray: false });
+
+    expect(pom.project.profiles.profile).to.be.an('object');
+    expect(pom.project.profiles.profile.id).to.equal('assembly');
+  });
+
+  it('is used when formats are configured', function () {
+    // given configured formats
+    context.config.maven.formats = ['zip', 'tar.gz'];
+
+    // when preparing the plugin and checking the built Maven command
+    plugin.beforeHook(context);
+    plugin.configure(context);
+    const mvnCommand = plugin._buildMavenCommand();
+
+    // then it contains the profile
+    expect(mvnCommand).to.equal('mvn deploy -Passembly');
+  });
+
+  it('is not used when no formats are configured', function () {
+    // given no formats are configured
+    // when preparing the plugin and checking the built Maven command
+    plugin.beforeHook(context);
+    plugin.configure(context);
+    const mvnCommand = plugin._buildMavenCommand();
+
+    // then it not contains the profile
+    expect(mvnCommand).to.equal('mvn deploy');
+  });
 })

--- a/tests/unit/assembly-test.js
+++ b/tests/unit/assembly-test.js
@@ -29,7 +29,7 @@ describe('Assembly descriptor', function () {
     // given configured formats
     context.config.maven.formats = ['zip', 'tar.gz'];
 
-    // when preparing the plguin and parsing the assembly descriptor XML
+    // when preparing the plugin and parsing the assembly descriptor XML
     plugin.beforeHook(context);
     plugin.configure(context);
     const xml = await parseString(plugin._buildAssemblyDescriptor(), { explicitArray: false });
@@ -39,5 +39,22 @@ describe('Assembly descriptor', function () {
     expect(xml.assembly.formats.format).to.have.property('length', 2);
     expect(xml.assembly.formats.format).to.include('zip');
     expect(xml.assembly.formats.format).to.include('tar.gz');
+  });
+
+  it('excludes Maven-specific files and directories', async function () {
+    // given configured formats
+    context.config.maven.formats = ['zip', 'tar.gz'];
+
+    // when preparing the plugin and parsing the assembly descriptor XML
+    plugin.beforeHook(context);
+    plugin.configure(context);
+    const xml = await parseString(plugin._buildAssemblyDescriptor(), { explicitArray: false });
+
+    // then the fileset configuration contains the relevant excludes
+    expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.be.an('array');
+    expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.have.property('length', 3);
+    expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.include('pom.xml');
+    expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.include('assembly.xml');
+    expect(xml.assembly.fileSets.fileSet.excludes.exclude).to.include('target/');
   });
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,7 +224,7 @@ assert-plus@^0.2.0:
 
 assertion-error@^1.0.1:
   version "1.1.0"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
 ast-types@0.9.6:
   version "0.9.6"
@@ -1295,7 +1295,7 @@ center-align@^0.1.1:
 
 chai@^4.1.2:
   version "4.1.2"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
   dependencies:
     assertion-error "^1.0.1"
     check-error "^1.0.1"
@@ -1340,7 +1340,7 @@ charm@^1.0.0:
 
 check-error@^1.0.1:
   version "1.0.2"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@1.6.1:
   version "1.6.1"
@@ -1661,7 +1661,7 @@ decamelize@^1.0.0:
 
 deep-eql@^3.0.0:
   version "3.0.1"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   dependencies:
     type-detect "^4.0.0"
 
@@ -2722,7 +2722,7 @@ get-caller-file@^1.0.0:
 
 get-func-name@^2.0.0:
   version "2.0.0"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4214,7 +4214,7 @@ path-to-regexp@0.1.7:
 
 pathval@^1.0.0:
   version "1.1.0"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -5123,7 +5123,7 @@ type-check@~0.3.2:
 
 type-detect@^4.0.0:
   version "4.0.8"
-  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@~1.6.15:
   version "1.6.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -1289,6 +1293,17 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
@@ -1322,6 +1337,10 @@ charm@^1.0.0:
   resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
   dependencies:
     inherits "^2.0.1"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@1.6.1:
   version "1.6.1"
@@ -1639,6 +1658,12 @@ debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -2694,6 +2719,10 @@ gauge@~2.7.3:
 get-caller-file@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4183,6 +4212,10 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -5087,6 +5120,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://nexus.dev.acrolinx.com/repository/npm-group/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@~1.6.15:
   version "1.6.15"


### PR DESCRIPTION
For our Maven-based build, we use the Maven assembly plug-in to produce a ZIP archive which is later inflated and copied to right directory when the build the main distribution package. Until now, we added a `pom.xml` and an assembly descriptor to each our Ember projects, building the Maven artifacts remained cumbersome. To get direct support via`ember deploy` I added support for producing such archives to this add-on.

Please review this pull request and let me know what I can do to improve it. I tried to follow your coding conventions. Unfortunately I missed your request to follow the conventional commits. Sorry about that.