### PR TITLE
Drop dependency on git-commit-id-plugin

### DIFF
--- a/lib/pom.xml.hbs
+++ b/lib/pom.xml.hbs
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>pl.project13.maven</groupId>
       <artifactId>git-commit-id-plugin</artifactId>
-      <version>2.2.3</version>
+      <version>3.0.1</version>
     </dependency>
   </dependencies>
 
@@ -48,7 +48,7 @@
     <plugins>
       <plugin>
         <groupId>pl.project13.maven</groupId>
-        <version>2.2.3</version>
+        <version>3.0.1</version>
         <artifactId>git-commit-id-plugin</artifactId>
         <configuration>
           <verbose>false</verbose>

--- a/lib/pom.xml.hbs
+++ b/lib/pom.xml.hbs
@@ -35,14 +35,6 @@
     {{/each}}
   </distributionManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>pl.project13.maven</groupId>
-      <artifactId>git-commit-id-plugin</artifactId>
-      <version>3.0.1</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <finalName>{{finalName}}</finalName>
     <plugins>


### PR DESCRIPTION
It's unnecessary to add the lib to the project dependencies. The plugin should be enough.

Also upgraded it to the latest version.